### PR TITLE
Change AWS IAM URL

### DIFF
--- a/app/Console.php
+++ b/app/Console.php
@@ -18,7 +18,7 @@ class Console extends Model
         ],
         [
             'name' => 'AWS Console w/IAM Account',
-            'url' => 'https://signin.aws.amazon.com/oauth?redirect_uri=https%3A%2F%2Fconsole.aws.amazon.com%2Fconsole%2Fhome%3Fstate%3DhashArgs%2523%26isauthcode%3Dtrue&client_id=arn%3Aaws%3Aiam%3A%3A015428540659%3Auser%2Fhomepage&response_type=code&iam_user=true&account=',
+            'url' => 'https://123456789.signin.aws.amazon.com/console/',
             'provider' => 'Amazon',
             'route' => 'amazon/with-account',
         ],


### PR DESCRIPTION
Change AWS IAM URL to a prettier URL based on AWS docs with an example Account ID

Based on https://docs.aws.amazon.com/IAM/latest/UserGuide/console.html#user-sign-in-page