### PR TITLE
add Google Search Console to Google provider

### DIFF
--- a/app/Console.php
+++ b/app/Console.php
@@ -35,6 +35,12 @@ class Console extends Model
             'route' => 'google/analytics',
         ],
         [
+            'name' => 'Google Search Console',
+            'url' => 'https://search.google.com/search-console',
+            'provider' => 'Google',
+            'route' => 'google/search',
+        ],
+        [
             'name' => 'Google Play Console',
             'url' => 'https://play.google.com/apps/publish',
             'provider' => 'Google',


### PR DESCRIPTION
I added Google Search Console to Google provider and placed it next to Google Analytics, because they are related and it fits well in the layout :-)