### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,0 +1,59 @@
+name: Test Build
+
+on:
+  push:
+
+jobs:
+  test:
+    name: PHP 7.3, Laravel 6.*
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.3
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache/files
+          key: php-7.3-laravel-6.*-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-7.3-laravel-6.*-composer-
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: npm-
+
+      - name: Copy ENV Laravel Configuration for CI
+        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+
+      - name: Install dependencies
+        run: |
+          composer require "orchestra/testbench:4.*" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction --no-progress --no-suggest
+          npm install
+
+      - name: Build Assets
+        run: npm run prod
+
+      - name: Generate key
+        run: php artisan key:generate
+
+      - name: Create DB and schemas
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: database/consoles.sqlite
+        run: |
+          mkdir -p database
+          touch database/consoles.sqlite
+          php artisan migrate
+
+      - name: Run PHP tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,8 +1,10 @@
 name: Test Build
 
 on:
+  pull_request:
   push:
-
+    branches:
+      - main
 jobs:
   test:
     name: PHP 7.3, Laravel 6.*
@@ -37,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "orchestra/testbench:4.*" --no-interaction --no-update
-          composer update --prefer-dist --no-interaction --no-progress --no-suggest
+          composer install --prefer-dist --no-interaction --no-progress --no-suggest
           npm install
 
       - name: Build Assets


### PR DESCRIPTION
Adds a CI workflow that checks `composer install`, `npm install`, `npm run prod`, `php artisan migrate` and `phpunit`.