### PR TITLE
Add Dropbox App Console

### DIFF
--- a/app/Console.php
+++ b/app/Console.php
@@ -112,6 +112,12 @@ class Console extends Model
             'provider' => 'Apple',
             'route' => 'apple/connect',
         ],
+        [
+            'name' => 'Dropbox App Console',
+            'url' => 'https://www.dropbox.com/developers/apps/',
+            'provider' => 'Dropbox',
+            'route' => 'dropbox',
+        ],
     ];
 
     /**

--- a/app/Provider.php
+++ b/app/Provider.php
@@ -39,7 +39,10 @@ class Provider extends Model
         ],
         [
             'name' => 'Apple'
-        ]
+        ],
+        [
+            'name' => 'Dropbox'
+        ],
     ];
 
     public function consoles()


### PR DESCRIPTION
This PR adds the Dropbox App Console found at: [`https://www.dropbox.com/developers/apps/`](https://www.dropbox.com/developers/apps/)